### PR TITLE
Add POST /tasks/{id}/complete endpoint

### DIFF
--- a/app/routes/tasks.py
+++ b/app/routes/tasks.py
@@ -73,5 +73,4 @@ def complete_task(task_id: int, db: Session = Depends(get_db)):
     db.refresh(task)
     return task
 
-# MISSING (Issue #2): No POST /tasks/{id}/complete endpoint
 # MISSING (Issue #3): No GET /tasks?status= filtering support

--- a/app/routes/tasks.py
+++ b/app/routes/tasks.py
@@ -62,5 +62,16 @@ def delete_task(task_id: int, db: Session = Depends(get_db)):
     db.delete(task)
     db.commit()
 
+
+@router.post("/{task_id}/complete")
+def complete_task(task_id: int, db: Session = Depends(get_db)):
+    task = db.query(Task).filter(Task.id == task_id).first()
+    if not task:
+        raise HTTPException(status_code=404, detail="Task not found")
+    task.status = "done"
+    db.commit()
+    db.refresh(task)
+    return task
+
 # MISSING (Issue #2): No POST /tasks/{id}/complete endpoint
 # MISSING (Issue #3): No GET /tasks?status= filtering support


### PR DESCRIPTION
## Summary

Implements Issue #2 — adds a dedicated `POST /tasks/{id}/complete` endpoint that marks a task as `done`.

## Changes
- Added `complete_task` route in `app/routes/tasks.py`

## Why
Provides a cleaner state transition endpoint instead of requiring callers to send a full `PUT` request body just to mark a task complete.

## Testing
- Existing `test_complete_task` in `tests/test_tasks.py` now passes ✅