### PR TITLE
Fix Issue #1: Add pagination to GET /tasks endpoint

### DIFF
--- a/app/routes/tasks.py
+++ b/app/routes/tasks.py
@@ -20,9 +20,8 @@ class TaskUpdate(BaseModel):
 
 
 @router.get("/")
-def list_tasks(db: Session = Depends(get_db)):
-    # BUG (Issue #1): This returns ALL tasks with no pagination support
-    return db.query(Task).all()
+def list_tasks(skip: int = 0, limit: int = 10, db: Session = Depends(get_db)):
+    return db.query(Task).offset(skip).limit(limit).all()
 
 
 @router.post("/", status_code=201)


### PR DESCRIPTION
## Summary

Fixes Issue #1 — the task list endpoint previously returned all tasks with no limit.

## Changes
- Added `skip` (default: `0`) and `limit` (default: `10`) query params to `GET /tasks/`
- Removed unbounded `db.query(Task).all()`

## Usage
```
GET /tasks/?skip=0&limit=10
```

## Testing
- `test_list_tasks_pagination` now passes ✅
- All other existing tests continue to pass ✅